### PR TITLE
New PleasantWeb branch

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ table {
 
 th, td {
   border: 2px solid var(--color-table-border);
-  padding: 0.5rem 1rem;
+  padding: 0.8rem;
   border-bottom: 1px solid transparent; /* Add underline to table rows */
   font-size: 18px; /* Increase font size for table data */
 }

--- a/options.html
+++ b/options.html
@@ -28,6 +28,7 @@
 
       h2 {
         font-size: 1.8rem;
+        text-align: center;
       }
 
       .content {

--- a/options.html
+++ b/options.html
@@ -43,6 +43,10 @@
         box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
       }
 
+      #checkboxes {
+        width: 70%;
+      }
+
       .form-control {
         font-family: Roboto, sans-serif;
         font-size: 1.3rem;

--- a/options.html
+++ b/options.html
@@ -29,6 +29,7 @@
       h2 {
         font-size: 1.8rem;
         text-align: center;
+        margin-bottom: 20px;
       }
 
       .content {

--- a/options.html
+++ b/options.html
@@ -26,6 +26,10 @@
         text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
       }
 
+      h2 {
+        font-size: 1.8rem;
+      }
+
       .content {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
This pull request includes a couple of enhancements to the PleasantWeb browser extension:              

1. Index.html:

- Increased padding for better spacing in table cells (th and td). The updated CSS rule now sets the padding to 0.8rem, improving readability.

2. Options.html:

- Decreased the font size of h2 headings to 1.8rem for a more balanced layout.
- Aligned h2 text to the centre for improved aesthetics and consistency.
- Increased the margin below h2 headings to 20px, providing better separation and enhancing readability.
- Adjusted the width of checkboxes for better alignment and visual harmony within the options interface.